### PR TITLE
Fix implicit marshalling of futures

### DIFF
--- a/sbt/src/main/scala/org/cakesolutions/akkapatterns/api/customer.scala
+++ b/sbt/src/main/scala/org/cakesolutions/akkapatterns/api/customer.scala
@@ -19,24 +19,24 @@ import spray.httpx.marshalling.MetaMarshallers
 class CustomerService(implicit val actorSystem: ActorSystem) extends Directives with Marshalling with MetaMarshallers with DefaultTimeout {
   def customerActor = actorSystem.actorFor("/user/application/customer")
 
+  import scala.concurrent.ExecutionContext.Implicits.global
+
   val route =
     path("customers" / JavaUUID) { id =>
       get {
         complete {
-          import scala.concurrent.ExecutionContext.Implicits.global
           (customerActor ? Get(id)).mapTo[Option[Customer]]
         }
       }
     } ~
       path("customers") {
         get {
-          complete{
-        	 val bob = (customerActor ? FindAll()).mapTo[List[Customer]]
-        	 bob
-            }
+          complete {
+            (customerActor ? FindAll()).mapTo[List[Customer]]
+          }
         } ~
           post {
-            content(as[RegisterCustomer]) { rc =>
+            entity(as[RegisterCustomer]) { rc =>
               complete((customerActor ? rc).mapTo[Either[NotRegisteredCustomer, RegisteredCustomer]])
             }
           }

--- a/sbt/src/main/scala/org/cakesolutions/akkapatterns/api/home.scala
+++ b/sbt/src/main/scala/org/cakesolutions/akkapatterns/api/home.scala
@@ -10,7 +10,7 @@ import spray.httpx.marshalling.MetaMarshallers
 
 case class SystemInfo(implementation: Implementation, host: String)
 
-class HomeService(implicit val actorSystem: ActorSystem) extends Directives with MetaMarshallers with Marshalling with DefaultTimeout {
+class HomeService(implicit val actorSystem: ActorSystem) extends Directives with Marshalling with MetaMarshallers with DefaultTimeout {
 
   def applicationActor = actorSystem.actorFor("/user/application")
 
@@ -18,7 +18,7 @@ class HomeService(implicit val actorSystem: ActorSystem) extends Directives with
     path(Slash) {
       get {
         complete {
-          import scala.concurrent.ExecutionContext.Implicits.global
+          import scala.concurrent.ExecutionContext.Implicits._
           val futureInfo = (applicationActor ? GetImplementation()).mapTo[Implementation].map {
             SystemInfo(_, InetAddress.getLocalHost.getCanonicalHostName)
           }

--- a/sbt/src/main/scala/org/cakesolutions/akkapatterns/api/marshalling.scala
+++ b/sbt/src/main/scala/org/cakesolutions/akkapatterns/api/marshalling.scala
@@ -1,0 +1,34 @@
+package org.cakesolutions.akkapatterns.api
+
+import java.util.UUID
+import spray.json._
+import spray.httpx.marshalling._
+import org.cakesolutions.akkapatterns.domain._
+import org.cakesolutions.akkapatterns.core.application._
+
+// might move upstream: https://github.com/spray/spray-json/issues/24
+@deprecated("expecting to move upstream", "") trait UuidMarshalling {
+  implicit object UuidJsonFormat extends JsonFormat[UUID] {
+    def write(x: UUID) = JsString(x toString ())
+    def read(value: JsValue) = value match {
+      case JsString(x) => UUID.fromString(x)
+      case x => deserializationError("Expected UUID as JsString, but got " + x)
+    }
+  }
+}
+
+trait Marshalling extends DefaultJsonProtocol with UuidMarshalling {
+
+  implicit val UserFormat = jsonFormat3(User)
+  implicit val NotRegisteredUserFormat = jsonFormat1(NotRegisteredUser)
+  implicit val RegisteredUserFormat = jsonFormat1(RegisteredUser)
+
+  implicit val AddressFormat = jsonFormat3(Address)
+  implicit val CustomerFormat = jsonFormat5(Customer)
+  implicit val RegisterCustomerFormat = jsonFormat2(RegisterCustomer)
+  implicit val NotRegisteredCustomerFormat = jsonFormat1(NotRegisteredCustomer)
+  implicit val RegisteredCustomerFormat = jsonFormat2(RegisteredCustomer)
+
+  implicit val ImplementationFormat = jsonFormat3(Implementation)
+  implicit val SystemInfoFormat = jsonFormat2(SystemInfo)
+}

--- a/sbt/src/main/scala/org/cakesolutions/akkapatterns/api/user.scala
+++ b/sbt/src/main/scala/org/cakesolutions/akkapatterns/api/user.scala
@@ -1,0 +1,29 @@
+package org.cakesolutions.akkapatterns.api
+
+import akka.actor.ActorSystem
+import spray.routing.Directives
+import akka.pattern.ask
+import spray.httpx.marshalling.MetaMarshallers
+import spray.httpx.SprayJsonSupport._
+import org.cakesolutions.akkapatterns.domain.User
+import org.cakesolutions.akkapatterns.core.application.{ NotRegisteredUser, RegisteredUser }
+
+/**
+ * @author janmachacek
+ */
+class UserService(implicit val actorSystem: ActorSystem) extends Directives with DefaultTimeout with Marshalling with MetaMarshallers {
+  def userActor = actorSystem.actorFor("/user/application/user")
+
+  val route =
+    path("user" / "register") {
+      post {
+        entity(as[User]) { user =>
+          complete {
+            import scala.concurrent.ExecutionContext.Implicits._
+            (userActor ? RegisteredUser(user)).mapTo[Either[NotRegisteredUser, RegisteredUser]]
+          }
+        }
+      }
+    }
+
+}


### PR DESCRIPTION
Yes, it was a dumb mistake – just missing an import.

Also changed for new Spray API: content -> entity
