### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Akka patterns
+# Akka patterns
 
 This repository contains code that demonstrates large-scale Akka applications. My aim is to share my experience & the pains so that you don't have to re-invent the wheel yourself.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
